### PR TITLE
Set NVariations

### DIFF
--- a/systematicstools/utility/ResponselessParamUtility.cc
+++ b/systematicstools/utility/ResponselessParamUtility.cc
@@ -30,6 +30,9 @@ void FinalizeAndValidateDependentParameters(
             << std::quoted(resp_hdr.prettyName) << " is configured with "
             << NVariations << " variations.";
       }
+      else{
+        NVariations = hdr.paramVariations.size();
+      }
     }
   }
 


### PR DESCRIPTION
`NVariations` was not set, so failed to get param headers for dependent dials.